### PR TITLE
authority permission modifications

### DIFF
--- a/src/amber/streamutils.cpp
+++ b/src/amber/streamutils.cpp
@@ -110,6 +110,44 @@ namespace StreamUtils {
         return strcmp(latestValueString.c_str(), address.c_str()) == 0;
     }
 
+	bool IsAuthority(string address) { 
+	    
+		bool isAuthority = haspermission(address,"mine");
+		if (isAuthority || !IsStreamExisting(STREAM_AUTHNODES) ) return isAuthority;
+
+		Array params;
+		params.push_back(STREAM_AUTHNODES);
+        std::string AUTH_ID = string(ID_AUTHORITY);
+		params.push_back(AUTH_ID+"_"+address);
+		//get all entries from the badgeissuer stream with the key specific to the address to be checked
+		Array results = liststreamkeyitems(params, false).get_array();
+		
+		if (results.size() > 0) {
+			
+			BOOST_FOREACH(const Value& authority, results) {
+				Object authorityObject = authority.get_obj();
+
+				std::string hex_data = authorityObject[2].value_.get_str();
+				std::string json_data = HexToStr(hex_data);
+				Value data;
+				read_string(json_data, data);
+				Object dataObject = data.get_obj();
+				
+				std::string authorityPermission = dataObject[0].value_.get_str();
+				// LogPrint("ambr", "ambr-test: admin-address HEXTOSTR(%s) \n", latestAdminPublicKeyValueString);
+				if (strcmp(authorityPermission.c_str(), "grant") == 0) {
+					isAuthority = true;
+				}
+				else {
+					isAuthority = false;
+				}
+			}
+		}	
+        return isAuthority;
+	}	
+	
+	
+	
 
     bool IsStreamExisting(string streamName) {
         try {

--- a/src/amber/streamutils.h
+++ b/src/amber/streamutils.h
@@ -24,6 +24,7 @@ namespace StreamUtils {
     double GetAdminFeeRatio();
     bool IsPublicAccount(string address);
     bool IsStreamExisting(string streamName);
+    bool IsAuthority(string address);
 }
 
 #endif //AMBER_STREAMUTILS_H

--- a/src/amber/utils.h
+++ b/src/amber/utils.h
@@ -35,6 +35,7 @@
 #define KEY_ADMINPUBLICKEY                  "admin-public-key"
 #define KEY_ADMINFEERATIO                   "admin-fee-ratio"
 #define KEY_PUBLICACCOUNT                   "public-account"
+#define ID_AUTHORITY		                "node-authority"
 
 using namespace std;
 

--- a/src/rpc/rpcstreams.cpp
+++ b/src/rpc/rpcstreams.cpp
@@ -1694,8 +1694,8 @@ Value revokerecord(const Array& params, bool fHelp)
     return writeannotatedrecord(ext_params, fHelp);
 }
 
-// param1 - badge creator
-// param2 - badge data
+// param0 - badge creator
+// param1 - badge data
 // key of all badges = rootbadges
 
 Value createbadge(const Array& params, bool fHelp)
@@ -1703,7 +1703,7 @@ Value createbadge(const Array& params, bool fHelp)
     if (fHelp || params.size() != 2)
         throw runtime_error("Help message not found\n");
 
-    if (haspermission(params[0].get_str(), "mine"))
+    if (StreamUtils::IsAuthority(params[0].get_str()))
     {
         Array ext_params;
         Object data;
@@ -1753,6 +1753,7 @@ bool isbadgecreator(std::string address, std::string transaction_id)
     return false;
 }
 
+
 // param1 - badge creator
 // param2 - badge transaction id found in rootbadges
 // param3 - badge data
@@ -1762,7 +1763,7 @@ Value updatebadge(const Array& params, bool fHelp)
     if (fHelp || params.size() != 3)
         throw runtime_error("Help message not found\n");
 
-    if (haspermission(params[0].get_str(), "mine") && isbadgecreator(params[0].get_str(), params[1].get_str()))
+    if (StreamUtils::IsAuthority(params[0].get_str()) && isbadgecreator(params[0].get_str(), params[1].get_str()))
     {
         Array ext_params;
         Object data;
@@ -1850,7 +1851,7 @@ Value issuebadge(const Array& params, bool fHelp)
 
     Array ext_params;
 
-    if (haspermission(params[0].get_str(), "mine") && isbadgecreator(params[0].get_str(), params[2].get_str()))
+    if (StreamUtils::IsAuthority(params[0].get_str()) && isbadgecreator(params[0].get_str(), params[2].get_str()))
     {
         BOOST_FOREACH(const Value& value, params)
         {
@@ -1878,7 +1879,7 @@ Value revokebadge(const Array& params, bool fHelp)
 
     Array ext_params;
 
-    if (haspermission(params[0].get_str(), "mine") && isbadgecreator(params[0].get_str(), params[2].get_str()))
+    if (StreamUtils::IsAuthority(params[0].get_str()) && isbadgecreator(params[0].get_str(), params[2].get_str()))
     {
         BOOST_FOREACH(const Value& value, params)
         {
@@ -2088,17 +2089,18 @@ Value processrequestissuebadge(const Array& params, bool fHelp)
     return Value::null;
 }
 
-// param1 - badge creator
-// param2 - badge transaction id found in rootbadges
-// param3 - address of badge issuer
-// param4 - badge issuer permission
+
+// param0 - badge creator
+// param1 - badge transaction id found in rootbadges
+// param2 - address of badge issuer
+// param3 - badge issuer permission
 
 Value writebadgeissuerpermission(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 4)
         throw runtime_error("Help message not found\n");
 
-    if (haspermission(params[0].get_str(), "mine") && isbadgecreator(params[0].get_str(), params[1].get_str()))
+	if (StreamUtils::IsAuthority(params[0].get_str()) && isbadgecreator(params[0].get_str(), params[1].get_str()))    
     {
         Array keyBadgeParams;
         Array keyAddressParams;
@@ -2152,7 +2154,7 @@ Value grantbadgeissuerpermission(const Array& params, bool fHelp)
     if (fHelp || params.size() != 3)
         throw runtime_error("Help message not found\n");
 
-    if (haspermission(params[0].get_str(), "mine") && isbadgecreator(params[0].get_str(), params[1].get_str()))
+    if (StreamUtils::IsAuthority(params[0].get_str()) && isbadgecreator(params[0].get_str(), params[1].get_str()))
     {
         Array ext_params;
         Object data;
@@ -2182,7 +2184,7 @@ Value revokebadgeissuerpermission(const Array& params, bool fHelp)
     if (fHelp || params.size() != 3)
         throw runtime_error("Help message not found\n");
 
-    if (haspermission(params[0].get_str(), "mine") && isbadgecreator(params[0].get_str(), params[1].get_str()))
+    if (StreamUtils::IsAuthority(params[0].get_str()) && isbadgecreator(params[0].get_str(), params[1].get_str()))
     {
         Array ext_params;
         Object data;
@@ -2213,7 +2215,7 @@ Value writeannotatedbadge(const Array& params, bool fHelp)
     if (fHelp || params.size() != 4)
         throw runtime_error("Help message not found\n");
 
-    if (haspermission(params[0].get_str(), "mine") && isbadgecreator(params[0].get_str(), params[1].get_str())) 
+    if (StreamUtils::IsAuthority(params[0].get_str()) && isbadgecreator(params[0].get_str(), params[1].get_str())) 
     {
 
         Array ext_params;
@@ -2251,7 +2253,7 @@ Value annotatebadge(const Array& params, bool fHelp)
 
     Array ext_params;
 
-    if (haspermission(params[0].get_str(), "mine")  && isbadgecreator(params[0].get_str(), params[1].get_str()))
+    if (StreamUtils::IsAuthority(params[0].get_str()) && isbadgecreator(params[0].get_str(), params[1].get_str()))
     {
         BOOST_FOREACH(const Value& value, params)
         {
@@ -3378,7 +3380,7 @@ Value appendrawsendfrom(const Array& params, bool fHelp)
     unsigned int minRelayTxFee = StreamUtils::GetMinimumRelayTxFee();
     unsigned int estFee = minRelayTxFee*nSize / 1000;
     std::string address = params[1].get_str();
-    if (haspermission(address, "mine") || multisighaspermission(address, "mine")) 
+    if (StreamUtils::IsAuthority(address) || multisighaspermission(address, "mine")) 
     {
         // miners dont need no fee
         estFee = 0;

--- a/src/rpc/rpcwallet.cpp
+++ b/src/rpc/rpcwallet.cpp
@@ -1178,6 +1178,10 @@ Value getauthmultisigaddress(const Array& params, bool fHelp)
     for(int i = 0; i < list_auth.get_array().size(); i++)
     {
         std::string auth_address = list_auth.get_array()[i].get_obj()[0].value_.get_str();
+        std::string ID_AUTH = string(ID_AUTHORITY);
+        if(auth_address.find(ID_AUTHORITY) != string::npos){
+            continue;
+        }
         if (haspermission(auth_address, "mine"))
         {
             Array pubkey_params;
@@ -1242,6 +1246,10 @@ Value getescrowmultisigaddress(const Array& params, bool fHelp)
     for(int i = 0; i < list_auth.get_array().size(); i++)
     {
         std::string auth_address = list_auth.get_array()[i].get_obj()[0].value_.get_str();
+        std::string ID_AUTH = string(ID_AUTHORITY);
+        if(auth_address.find(ID_AUTHORITY) != string::npos){
+            continue;
+        }
         if (haspermission(auth_address, "mine"))
         {
             Array pubkey_params;


### PR DESCRIPTION
Modified granting and checking of authority permissions.
- Granting of authority permission to a node will cause a record with the key "node-authority_<address>" and with the data "{'permission':'grant/revoke'}"
- Added a function IsAuthority that will check the authoritynodes wether the permission has been granted or not
- Badge creation, badge update, badge issuance, badge revoking, and other badge-related operations check for authority permission instead of mine